### PR TITLE
DES-197 Serial fix for EvoLogics modems

### DIFF
--- a/DESERT_Framework/DESERT/physical/uwevologicss2cmodem/uwevologicss2cmodem.cpp
+++ b/DESERT_Framework/DESERT/physical/uwevologicss2cmodem/uwevologicss2cmodem.cpp
@@ -204,10 +204,12 @@ UwEvoLogicsS2CModem::command(int argc, const char *const *argv)
 		if (!strcmp(argv[1], "setConnector")) {
 			if(!strcmp(argv[2], "SOCKET")) {
 				p_connector.reset(new UwSocket());
+				p_interpreter->setTerminator("\n");
 				return TCL_OK;
 			}
 			if(!strcmp(argv[2], "SERIAL")) {
 				p_connector.reset(new UwSerial());
+				p_interpreter->setTerminator("\r");
 				return TCL_OK;
 			}
 			fprintf(stderr, "Invalid connector type, choose between SOCKET and SERIAL");

--- a/DESERT_Framework/DESERT/physical/uwevologicss2cmodem/uwinterpreters2c.h
+++ b/DESERT_Framework/DESERT/physical/uwevologicss2cmodem/uwinterpreters2c.h
@@ -234,6 +234,15 @@ public:
          */
        std::shared_ptr<USBLInfo> getUSBLInfo();
 
+
+        /** Method that sets the terminator for the AT commands wrtten to device
+         * @param[in] terminator type of the terminator
+         */
+       void setTerminator(std::string terminator)
+       {
+              w_term = terminator;
+       };
+
 private:
 	std::string sep; /**< Separator for paramters fo the commands: a comma */
 	std::string r_term; /**<Terminating sequence for commands read from device*/


### PR DESCRIPTION
The EvoLogics driver was using \n terminator to send socket commands and \r\n to parse the received ones. The serial counterpart uses the \r terminator to send commands and \r\n to parse those which are received.