### PR TITLE
fix: fixed redefinition of pi in addon uwsmposition

### DIFF
--- a/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.cpp
+++ b/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.cpp
@@ -40,6 +40,9 @@
 #include "uwsmposition.h"
 #include <iostream>
 
+#define sgn(x) (((x) == 0.0) ? 0.0 : ((x) / fabs(x)))
+#define pi_local (4 * atan(1.0))
+
 static class UWSMPositionClass : public TclClass
 {
 public:

--- a/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.cpp
+++ b/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.cpp
@@ -194,12 +194,12 @@ UWSMPosition::update(double now)
 		theta = acos((Zdest_ - Zsorg_) / theta_den);
 
 		if (Xdest_ - Xsorg_ == 0)
-			gamma = pi / 2 * sgn(Ydest_ - Ysorg_);
+			gamma = pi_local / 2 * sgn(Ydest_ - Ysorg_);
 		else
 			gamma = atan((Ydest_ - Ysorg_) / (Xdest_ - Xsorg_));
 
 		if ((Xdest_ - Xsorg_) < 0.0)
-			gamma += (Ysorg_ - Ydest_) >= 0.0 ? pi : -pi;
+			gamma += (Ysorg_ - Ydest_) >= 0.0 ? pi_local : -pi_local;
 
 		x_ = Xsorg_ + (speed_ * (now - trgTime_)) * sin(theta) * cos(gamma);
 		y_ = Ysorg_ + (speed_ * (now - trgTime_)) * sin(theta) * sin(gamma);

--- a/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.cpp
+++ b/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.cpp
@@ -40,8 +40,16 @@
 #include "uwsmposition.h"
 #include <iostream>
 
-#define sgn(x) (((x) == 0.0) ? 0.0 : ((x) / fabs(x)))
-#define pi_local (4 * atan(1.0))
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+
+#include <cmath>
+
+static constexpr double
+sgn(double val)
+{
+	return (val > 0.0) ? 1.0 : ((val < 0.0) ? -1.0 : 0.0);
+}
 
 static class UWSMPositionClass : public TclClass
 {
@@ -197,12 +205,12 @@ UWSMPosition::update(double now)
 		theta = acos((Zdest_ - Zsorg_) / theta_den);
 
 		if (Xdest_ - Xsorg_ == 0)
-			gamma = pi_local / 2 * sgn(Ydest_ - Ysorg_);
+			gamma = M_PI / 2 * sgn(Ydest_ - Ysorg_);
 		else
 			gamma = atan((Ydest_ - Ysorg_) / (Xdest_ - Xsorg_));
 
 		if ((Xdest_ - Xsorg_) < 0.0)
-			gamma += (Ysorg_ - Ydest_) >= 0.0 ? pi_local : -pi_local;
+			gamma += (Ysorg_ - Ydest_) >= 0.0 ? M_PI : -M_PI;
 
 		x_ = Xsorg_ + (speed_ * (now - trgTime_)) * sin(theta) * cos(gamma);
 		y_ = Ysorg_ + (speed_ * (now - trgTime_)) * sin(theta) * sin(gamma);
@@ -327,3 +335,4 @@ UWSMPosition::getSpeed() const
 {
 	return speed_;
 }
+#endif

--- a/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.h
+++ b/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.h
@@ -50,9 +50,6 @@
 
 #include <node-core.h>
 
-#define sgn(x) (((x) == 0.0) ? 0.0 : ((x) / fabs(x)))
-#define pi_local (4 * atan(1.0))
-
 class UWSMPosition : public Position
 {
 public:

--- a/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.h
+++ b/DESERT_Framework/DESERT/mobility/uwsmposition/uwsmposition.h
@@ -51,7 +51,7 @@
 #include <node-core.h>
 
 #define sgn(x) (((x) == 0.0) ? 0.0 : ((x) / fabs(x)))
-#define pi (4 * atan(1.0))
+#define pi_local (4 * atan(1.0))
 
 class UWSMPosition : public Position
 {


### PR DESCRIPTION
Redefinition of `pi` in the header of the addon `uwsmposition` threw `expected unqualified-id before numeric constant` with gcc 16 (got this error in particular with `gcc (GCC) 16.1.1 20260515 (Red Hat 16.1.1-2)`).

Renamed `pi` to `pi_local` to fix the error.