### PR TITLE
fix: added zero check to avoid integer overflow

### DIFF
--- a/DESERT_Framework/DESERT/physical/uw-al/packer.h
+++ b/DESERT_Framework/DESERT/physical/uw-al/packer.h
@@ -173,19 +173,21 @@ public:
 	static T
 	restoreSignedValue(T _header_field, const uint32_t &_num_compressed_bits)
 	{
-		if (_num_compressed_bits < sizeof(_header_field) * 8) {
-			bitset<sizeof(_header_field) * 8> my_bitset(_header_field);
-			if (my_bitset[_num_compressed_bits - 1] == 1) {
-				for (size_t i = _num_compressed_bits;
-						i < sizeof(_header_field) * 8;
-						++i) {
-					my_bitset.set(i, 1);
-				}
-			}
-			return static_cast<T>(my_bitset.to_ulong());
-		} else {
+		constexpr size_t total_bits = sizeof(T) * 8;
+
+		// If no compressed bits to extend, nothing to do:
+		// there is no sign bit to check.
+		if (_num_compressed_bits == 0 || _num_compressed_bits >= total_bits) {
 			return _header_field;
 		}
+
+		std::bitset<total_bits> my_bitset(_header_field);
+		if (my_bitset.test(_num_compressed_bits - 1)) {
+			for (size_t i = _num_compressed_bits; i < total_bits; ++i) {
+				my_bitset.set(i, true);
+			}
+		}
+		return static_cast<T>(my_bitset.to_ulong());
 	}
 
 	/**


### PR DESCRIPTION
This error is caused by a missing null check inside the method `restoreSignedValue(…)` of the file `/home/pietro/signet/repos/DESERT_Underwater/DESERT_Framework/DESERT/physical/uw-al/packer.h`.

Specifically, at line `178`, the bitset `my_bitset` (created a couple of lines above) is accessed at position `_num_compressed_bits - 1`. When `_num_compressed_bits` is equal to `0`, the value overflows to `4294967295`, accessing unwanted memory and throwing an assertion:

```
/usr/include/c++/16/bitset:1294: std::bitset<_Nb>::reference std::bitset<_Nb>::operator[](std::size_t) [with long unsigned int _Nb = 32; std::size_t = long unsigned int]: Assertion '__position < _Nb' failed.
```

In my case, the specific call that causes this error is in `DESERT_Underwater/DESERT_Framework/DESERT/physical/uw-al/packer_common/packer_common.cpp` on line `323` inside `packerCOMMON::unpackMyHdr()`. When calling `restoreSignedValue()`, `ch->errbitcnt_` is set to `0`, causing the error.

This has always happened but was ignored, as by itself it does not seem to create any error. With newer versions of g++ (>=g++14), to avoid out-of-bounds memory access, the compilers are set up to throw hard errors. I was specifically using `g++ (GCC) 16.1.1 20260515 (Red Hat 16.1.1-2)` with Fedora 44.

I encountered this error while setting the destination address in the Application layer to `255`, to use the broadcast functionality in `ns`. This error will be present every time the `unpackMyHdr()` method is called.

The fix adds a check for `_num_compressed_bits == 0` and changes the way to access the bitset from the `operator[]` to `.test()`, which functions the exact same way but returns an error, not an assertion, in case of future errors.