### PR TITLE
Correct typo in recvSyncClMsg comment

### DIFF
--- a/DESERT_Framework/DESERT/network/uwflooding/uwflooding.h
+++ b/DESERT_Framework/DESERT/network/uwflooding/uwflooding.h
@@ -117,7 +117,7 @@ protected:
 
 	/**
 	 * Cross-Layer messages asynchronous interpreter. Used to retrive the IP
-	 * od the current node from the IP module.
+	 * of the current node from the IP module.
 	 *
 	 * @param ClMessage* an instance of ClMessage that represent the message
 	 * received and used for the answer.


### PR DESCRIPTION
Fix typo in comment regarding IP retrieval ("od" to "of")